### PR TITLE
#177 支持した人のアイコンを支持のボタンの下に表示する

### DIFF
--- a/custom-vote-button.css
+++ b/custom-vote-button.css
@@ -1,41 +1,56 @@
-
+/* Custom Vote Button */
+.qa-vote-buttons {
+  height: 40px;
+}
 .qa-vote-first-button {
-top: 12px;
+  top: 12px;
 }
 .qa-vote-one-button {
-top: 12px;
+  top: 12px;
 }
 .qa-netvote-count {
-margin-top: 17px;
+  margin-top: 17px;
 }
 .qa-vote-up-button,
 .qa-vote-up-hover,
 .qa-vote-up-disabled,
 .qa-voted-up-button,
 .qa-voted-up-hover {
-background: url(img/thumbs.png) no-repeat;
-height: 30px;
-width: 30px;
+  background: url(img/thumbs.png) no-repeat;
+  height: 30px;
+  width: 30px;
 }
 .qa-vote-up-button {
-background-position: 0 0;
-color: #f1c96b;
+  background-position: 0 0;
+  color: #f1c96b;
 }
 .qa-vote-up-disabled {
-background-position: 0 -120px;
-color: #CCC;
+  background-position: 0 -120px;
+  color: #CCC;
 }
 .qa-vote-up-hover,
 .qa-vote-up-button:hover {
-background-position: 0 -30px;
-color: #f1c96b;
+  background-position: 0 -30px;
+  color: #f1c96b;
 }
 .qa-voted-up-button {
-background-position: 0 -60px;
-color: #f1c96b;
+  background-position: 0 -60px;
+  color: #f1c96b;
 }
 .qa-voted-up-hover,
 .qa-voted-up-button:hover {
-background-position: 0 -90px;
-color: #f1c96b;
+  background-position: 0 -90px;
+  color: #f1c96b;
+}
+
+/* Vote avatars */
+.voted-avatar-list {
+  margin-top: 10px;
+}
+.voted-avatar-list ul{
+  list-style-type: none;
+}
+li.qa-voted-avatar {
+  float: left;
+  margin: 3px 3px 0 0;
 }

--- a/custom-vote-button.css
+++ b/custom-vote-button.css
@@ -1,0 +1,41 @@
+
+.qa-vote-first-button {
+top: 12px;
+}
+.qa-vote-one-button {
+top: 12px;
+}
+.qa-netvote-count {
+margin-top: 17px;
+}
+.qa-vote-up-button,
+.qa-vote-up-hover,
+.qa-vote-up-disabled,
+.qa-voted-up-button,
+.qa-voted-up-hover {
+background: url(img/thumbs.png) no-repeat;
+height: 30px;
+width: 30px;
+}
+.qa-vote-up-button {
+background-position: 0 0;
+color: #f1c96b;
+}
+.qa-vote-up-disabled {
+background-position: 0 -120px;
+color: #CCC;
+}
+.qa-vote-up-hover,
+.qa-vote-up-button:hover {
+background-position: 0 -30px;
+color: #f1c96b;
+}
+.qa-voted-up-button {
+background-position: 0 -60px;
+color: #f1c96b;
+}
+.qa-voted-up-hover,
+.qa-voted-up-button:hover {
+background-position: 0 -90px;
+color: #f1c96b;
+}

--- a/custom-vote-button.css
+++ b/custom-vote-button.css
@@ -53,4 +53,23 @@
 li.qa-voted-avatar {
   float: left;
   margin: 3px 3px 0 0;
+  width:20px;
+  height:20px;
+  overflow:hidden;
+  position:relative;
+  display: block;
+}
+li.qa-voted-avatar .qa-avatar-link img {
+  max-width:140%;
+  min-width:100%;
+  width:auto;
+  min-height:100%;
+  max-height:140%;
+  height:auto;
+  position:absolute;
+  top:-40%;
+  right:-40%;
+  bottom:-40%;
+  left:-40%;
+  margin:auto;
 }

--- a/custom-vote-button.js
+++ b/custom-vote-button.js
@@ -1,13 +1,21 @@
 $(document).ready(function(){
-	var va_lists = [];
-	$(".voted-avatar-list").each(function(i, elem) {
-		va_lists.push($(elem).height());
-	});
-	console.log(va_lists);
-	// var favbutton = $(".qa-q-view-favorite .qa-favoriting");
-	// var favpos = favbutton.position();
-	// var asel = $(".qa-a-selection");
-	// var aselpos = asel.position();
-	// favbutton.css("top", favpos.top + aicons_height + "px");
-	// asel.css("top", aselpos.top + aicons_height + "px");
+
+	var set_buttons_height = function() {
+		var avatar_list_heights = [];
+		$(".voted-avatar-list").each(function(i, elem) {
+			avatar_list_heights.push($(elem).height());
+		});
+
+		var favbutton = $(".qa-q-view-favorite .qa-favoriting");
+		var favpos = favbutton.position();
+
+		favbutton.css("top", favpos.top + avatar_list_heights[0] + "px");
+		$(".qa-a-selection").each(function(i, elem) {
+			var elempos = $(elem).position();
+			$(elem).css("top", elempos.top + avatar_list_heights[i + 1] + "px");
+		});
+	}
+
+	set_buttons_height();
+
 });

--- a/custom-vote-button.js
+++ b/custom-vote-button.js
@@ -1,0 +1,13 @@
+$(document).ready(function(){
+	var va_lists = [];
+	$(".voted-avatar-list").each(function(i, elem) {
+		va_lists.push($(elem).height());
+	});
+	console.log(va_lists);
+	// var favbutton = $(".qa-q-view-favorite .qa-favoriting");
+	// var favpos = favbutton.position();
+	// var asel = $(".qa-a-selection");
+	// var aselpos = asel.position();
+	// favbutton.css("top", favpos.top + aicons_height + "px");
+	// asel.css("top", aselpos.top + aicons_height + "px");
+});

--- a/qa-custom-vote-button-layer.php
+++ b/qa-custom-vote-button-layer.php
@@ -15,9 +15,12 @@ class qa_html_theme_layer extends qa_html_theme_base
 	{
 		$this->vote_buttons($post);
 		$this->vote_count($post);
-		$this->vote_avatars($post);
+		if (!qa_is_mobile_probably()) {
+			$this->vote_avatars($post);
+		}
 		$this->vote_clear();
 	}
+
 	public function vote_buttons($post)
 	{
 		$this->output('<div class="qa-vote-buttons '.(($post['vote_view'] == 'updown') ? 'qa-vote-buttons-updown' : 'qa-vote-buttons-net').'">');
@@ -67,5 +70,13 @@ class qa_html_theme_layer extends qa_html_theme_base
 
 	public function vote_avatars()
 	{
+		$this->output('<div class="voted-avatar-list" ><ul>');
+		$avatar = '<li class="qa-voted-avatar">
+	<a href="http://dev.q2a.com/user/testuser1" class="qa-avatar-link" original-title="" title=""><img src="http://dev.q2a.com/?qa=image&qa_blobid=7162451989466937721&qa_size=20" width="20" height="20" class="qa-avatar-image" alt=""></a>
+</li>';
+		for($i = 1; $i < 10; $i++) {
+			$this->output($avatar);
+		}
+		$this->output('</ul></div>');
 	}
 }

--- a/qa-custom-vote-button-layer.php
+++ b/qa-custom-vote-button-layer.php
@@ -3,7 +3,7 @@
 class qa_html_theme_layer extends qa_html_theme_base
 {
 	const TARGET_DATE = '2016-07-15';
-	const AVATAR_SIZE = 20;
+	const AVATAR_SIZE = 80;
 
 	public function head_css()
 	{
@@ -172,7 +172,12 @@ IN ( SELECT userid FROM ^uservotes WHERE postid = # AND vote = 1 )
 	private function is_q_list($post)
 	{
 		$keys = array_keys($post);
+		if (count($keys) <= 19) {
+			// ajax 呼び出しの場合keyの数が19個
+			return false;
+		}
 		foreach ($keys as $key) {
+			// 質問リストには c_list なし
 			if ($key === 'c_list') {
 				return false;
 			}

--- a/qa-custom-vote-button-layer.php
+++ b/qa-custom-vote-button-layer.php
@@ -17,7 +17,8 @@ class qa_html_theme_layer extends qa_html_theme_base
 	{
 		$this->vote_buttons($post);
 		$this->vote_count($post);
-		if (!qa_is_mobile_probably()) {
+		// モバイルでない かつ 投稿リスト内ではない
+		if (!qa_is_mobile_probably() && !$this->is_q_list($post)) {
 			$this->vote_avatars($post);
 		}
 		$this->vote_clear();
@@ -70,6 +71,16 @@ class qa_html_theme_layer extends qa_html_theme_base
 		qa_html_theme_base::vote_count($post);
 	}
 
+	public function body_footer()
+	{
+		qa_html_theme_base::body_footer();
+		if (!qa_is_mobile_probably() && $this->template === 'question') {
+			$plugin_url = qa_path('qa-plugin/q2a-custom-vote-button/');
+			$script = $plugin_url . 'custom-vote-button.js';
+			$this->output('<script type="text/javascript" src="'.$script.'"></script>');
+		}
+	}
+
 	/**
 	 * 支持した人のアイコンを表示する
 	 * @param  array $post その投稿
@@ -78,13 +89,16 @@ class qa_html_theme_layer extends qa_html_theme_base
 	public function vote_avatars($post)
 	{
 		$voted_user_icons = $this->get_voted_user_icons($post);
+		$this->output('<div class="voted-avatar-list" >');
 		if (!empty($voted_user_icons)) {
-			$this->output('<div class="voted-avatar-list" ><ul>');
+			$this->output('<ul>');
 			foreach ( $voted_user_icons as $icon ) {
 				$this->output('<li class="qa-voted-avatar">'.$icon.'<li>');
 			}
-			$this->output('</ul></div>');
+			$this->output('</ul>');
 		}
+		$this->output('<div style="clear:both;"></div>');
+		$this->output('</div>');
 	}
 
 	/**
@@ -148,5 +162,21 @@ IN ( SELECT userid FROM ^uservotes WHERE postid = # AND vote = 1 )
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * 質問リスト内の投稿かどうか
+	 * @param  array  $post 現在の投稿
+	 * @return boolean      投稿リスト内ならtrue
+	 */
+	private function is_q_list($post)
+	{
+		$keys = array_keys($post);
+		foreach ($keys as $key) {
+			if ($key === 'c_list') {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/qa-custom-vote-button-layer.php
+++ b/qa-custom-vote-button-layer.php
@@ -6,53 +6,18 @@ class qa_html_theme_layer extends qa_html_theme_base
 	public function head_css()
 	{
 		qa_html_theme_base::head_css();
-		$plugin_url = '/qa-plugin/q2a-custom-vote-button/';
-		$button_img = $plugin_url . 'img/thumbs.png';
-		$css = "
-.qa-vote-first-button {
-	top: 12px;
-}
-.qa-vote-one-button {
-	top: 12px;
-}
-.qa-netvote-count {
-	margin-top: 17px;
-}
-.qa-vote-up-button,
-.qa-vote-up-hover,
-.qa-vote-up-disabled,
-.qa-voted-up-button,
-.qa-voted-up-hover {
-	background: url($button_img) no-repeat;
-	height: 30px;
-	width: 30px;
-}
-.qa-vote-up-button {
-    background-position: 0 0;
-    color: #f1c96b;
-}
-.qa-vote-up-disabled {
-    background-position: 0 -120px;
-    color: #CCC;
-}
-.qa-vote-up-hover,
-.qa-vote-up-button:hover {
-    background-position: 0 -30px;
-    color: #f1c96b;
-}
-.qa-voted-up-button {
-    background-position: 0 -60px;
-    color: #f1c96b;
-}
-.qa-voted-up-hover,
-.qa-voted-up-button:hover {
-    background-position: 0 -90px;
-    color: #f1c96b;
-}
-";
-		$this->output('<style>', $css, '</style>');
+		$plugin_url = qa_path('qa-plugin/q2a-custom-vote-button/');
+		$css = $plugin_url . 'custom-vote-button.css';
+		$this->output('<link rel="stylesheet" type="text/css" href="'.$css.'">');
 	}
 
+	public function voting_inner_html($post)
+	{
+		$this->vote_buttons($post);
+		$this->vote_count($post);
+		$this->vote_avatars($post);
+		$this->vote_clear();
+	}
 	public function vote_buttons($post)
 	{
 		$this->output('<div class="qa-vote-buttons '.(($post['vote_view'] == 'updown') ? 'qa-vote-buttons-updown' : 'qa-vote-buttons-net').'">');
@@ -94,10 +59,13 @@ class qa_html_theme_layer extends qa_html_theme_base
 		$this->output('</div>');
 	}
 
-		public function vote_count($post)
-		{
-			$post['netvotes_view']['prefix'] = '';
-			qa_html_theme_base::vote_count($post);
-		}
+	public function vote_count($post)
+	{
+		$post['netvotes_view']['prefix'] = '';
+		qa_html_theme_base::vote_count($post);
+	}
 
+	public function vote_avatars()
+	{
+	}
 }


### PR DESCRIPTION
- 支持した人のアイコンを表示
  - アイコンを登録していないと表示されない
  - 支持ボタンを押すと自動で追加
  - 支持を取り消すと自動で削除
  - 2016年7月15日以降に投稿された質問・回答にのみ表示
  - モバイルでは非表示
  - 質問リストでは非表示

アイコンが増えるとフォローボタンやベストアンサーボタンと重なってしまうので
jsでボタン位置の調整を行っております
